### PR TITLE
Update vim to v9.0.1582 & fix alpine to v3.18

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,41 @@
 #!/bin/bash
 
-docker run -i --rm -v "$PWD":/out -w /root alpine /bin/sh <<EOF
-apk add gcc make musl-dev ncurses-static
-wget https://github.com/vim/vim/archive/v8.1.1045.tar.gz
-tar xvfz v8.1.1045.tar.gz
+docker run -i --rm -e vim_version=9.0.1582 -v "$PWD":/out -w /root alpine /bin/sh <<EOF
+set -e
+
+# install build-time dependencies
+apk add gcc make musl-dev ncurses-static curl upx
+
+# download vim tarball and extract it
+curl -Ls https://github.com/vim/vim/archive/refs/tags/v\$vim_version.tar.gz | tar xz
 cd vim-*
-LDFLAGS="-static" ./configure --disable-channel --disable-gpm --disable-gtktest --disable-gui --disable-netbeans --disable-nls --disable-selinux --disable-smack --disable-sysmouse --disable-xsmp --enable-multibyte --with-features=huge --without-x --with-tlib=ncursesw
-make
+
+# configure, compile and install
+LDFLAGS="-static" \
+	./configure --disable-channel \
+		--disable-gpm \
+		--disable-gtktest \
+		--disable-gui \
+		--disable-netbeans \
+		--disable-nls \
+		--disable-selinux \
+		--disable-smack \
+		--disable-sysmouse \
+		--disable-xsmp \
+		--enable-multibyte \
+		--with-features=huge \
+		--without-x \
+		--with-tlib=ncursesw
+make -j3
 make install
+
+# copy compiled output
 mkdir -p /out/vim
 cp -r /usr/local/* /out/vim
-strip /out/bin/vim
+
+# make it smaller
+strip /out/vim/bin/vim
+upx /out/vim/bin/vim
+
 chown -R $(id -u):$(id -g) /out/vim
 EOF

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker run -i --rm -e vim_version=9.0.1582 -v "$PWD":/out -w /root alpine /bin/sh <<EOF
+docker run -i --rm -e vim_version=9.0.1582 -v "$PWD":/out -w /root alpine:3.18 /bin/sh <<EOF
 set -e
 
 # install build-time dependencies


### PR DESCRIPTION
* Updates version to v9.0.1582
* Use curl to download
* Untar the tarball on-the-fly
* Use upx to compress the binary (saves ~50% binary size)
* Adds some comments & breaks long lines
* Fixes alpine docker image to v3.18